### PR TITLE
Fix Generator Asset change detection

### DIFF
--- a/rosetta_generator/build.yaml
+++ b/rosetta_generator/build.yaml
@@ -9,7 +9,10 @@ builders:
     target: ":rosetta_generator"
     import: "package:rosetta_generator/rosetta_generator.dart"
     builder_factories: ["rosettaStoneBuilder"]
-    build_extensions: {".dart": [".rosetta.g.part"]}
+    build_extensions: {
+      ".dart": [".rosetta.g.part"],
+      ".json": [".rosetta.json"]
+    }
     auto_apply: dependents
     build_to: cache
     applies_builders: ["source_gen|combining_builder"]

--- a/rosetta_generator/lib/src/rosetta_generator.dart
+++ b/rosetta_generator/lib/src/rosetta_generator.dart
@@ -6,6 +6,7 @@ import 'package:analyzer/dart/element/element.dart';
 import 'package:build/build.dart';
 import 'package:code_builder/code_builder.dart';
 import 'package:dart_style/dart_style.dart';
+import 'package:glob/glob.dart';
 import 'package:path/path.dart' show basename;
 import 'package:recase/recase.dart';
 import 'package:rosetta/rosetta.dart';
@@ -43,7 +44,7 @@ class RosettaStoneGenerator extends GeneratorForAnnotation<Stone> {
     Map<String, List<String>> keyMap;
 
     try {
-      keyMap = await getKeyMap(path);
+      keyMap = await getKeyMap(buildStep, path);
     } on FormatException catch (_) {
       throw InvalidGenerationSourceError(
         "Invalid JSON format! Validate the JSON's contents.",

--- a/rosetta_generator/lib/src/rosetta_utils.dart
+++ b/rosetta_generator/lib/src/rosetta_utils.dart
@@ -13,14 +13,13 @@ Future<List<String>> getLanguages(String path) async {
   return fileNames.map((name) => name.replaceAll(".json", "")).toList();
 }
 
-Future<Map<String, List<String>>> getKeyMap(String path) async {
-  Directory directory = Directory(path);
-
+Future<Map<String, List<String>>> getKeyMap(BuildStep step, String path) async {
   Map<String, List<String>> keyMap = Map();
 
-  for (FileSystemEntity entity in directory.listSync()) {
-    File file = File(entity.path);
-    Map<String, dynamic> jsonMap = json.decode(await file.readAsString());
+  var assets = await step.findAssets(Glob(path, recursive: true)).toList();
+
+  for (var entity in assets) {
+    Map<String, dynamic> jsonMap = json.decode(await step.readAsString(entity));
     Map<String, String> translationMap = jsonMap
         .map<String, String>((key, value) => MapEntry(key, value as String));
 


### PR DESCRIPTION
Issue #19

Generator used simple dart:io file actions for parsing the translation JSON files. The AssetReader didn't detect the read JSON Assets as input dependecies, this is the reason why build_runner watch did not start the generator, if the source JSON files changed.