### PR TITLE
Optimize the generator to generate a code, matching stricter analysis options

### DIFF
--- a/rosetta_generator/CHANGELOG.md
+++ b/rosetta_generator/CHANGELOG.md
@@ -1,3 +1,14 @@
+# v0.2.1
+
+## Improvements:
+* Optimize the generator to generate a stricter code, matching stricter analysis option
+* fix: implicit-dynamic warnings in the generated code
+* fix: use final instead of vars
+* add: more typings where finals replace vars
+* fix: avoid using this where the resolve method is called
+* change: use static const instead of static final props for the generated Enum class for Keys
+* add: typed MapEntry
+
 # v0.2.0
 
 ## Improvements:

--- a/rosetta_generator/lib/src/consts.dart
+++ b/rosetta_generator/lib/src/consts.dart
@@ -15,6 +15,7 @@ const String strInnerHelper = "_\$";
 const Reference refLocale = Reference(strLocaleName);
 const Reference refOverrideAnnotation = Reference("override");
 
+const Reference refResolve = Reference(strResolveMethodName);
 const Reference refTranslate = Reference(strTranslateMethodName);
 const Reference refTranslations = Reference(strTranslationsFieldName);
 const Reference refResolutions = Reference(strResolutionsName);

--- a/rosetta_generator/lib/src/delegate.dart
+++ b/rosetta_generator/lib/src/delegate.dart
@@ -74,7 +74,6 @@ Method _load(String className) {
             .newInstance([])
             .assignFinal(fieldName, typeOf(className))
             .statement,
-        // refer(className).newInstance([]).assignVar(fieldName).statement,
         field.property(strLoadMethodName).call([refLocale]).awaited.statement,
         field.returned.statement,
       ]),

--- a/rosetta_generator/lib/src/delegate.dart
+++ b/rosetta_generator/lib/src/delegate.dart
@@ -32,7 +32,7 @@ Method _isSupported(List<String> supportedLanguages) => Method(
         ..name = 'isSupported'
         ..requiredParameters.add(localeParameter)
         ..lambda = true
-        ..body = literalConstList(supportedLanguages)
+        ..body = literalConstList(supportedLanguages, stringType)
             .property("contains")
             .call([refLocale.property("languageCode")]).code,
     );
@@ -70,7 +70,11 @@ Method _load(String className) {
       ..modifier = MethodModifier.async
       ..requiredParameters.add(localeParameter)
       ..body = Block.of([
-        refer(className).newInstance([]).assignVar(fieldName).statement,
+        refer(className)
+            .newInstance([])
+            .assignFinal(fieldName, typeOf(className))
+            .statement,
+        // refer(className).newInstance([]).assignVar(fieldName).statement,
         field.property(strLoadMethodName).call([refLocale]).awaited.statement,
         field.returned.statement,
       ]),

--- a/rosetta_generator/lib/src/helper.dart
+++ b/rosetta_generator/lib/src/helper.dart
@@ -93,16 +93,19 @@ Method generateLoader(Stone stone, Map<String, Spec> interceptorMap) {
         assetLoader
             .call([literalString(assetLoaderTemplate)])
             .awaited
-            .assignVar(strLoadJsonStr)
+            .assignFinal(strLoadJsonStr, stringType)
+            // .assignVar(strLoadJsonStr)
             .statement,
         decodeJson
             .call([refJsonStr])
-            .assignVar(strLoadJsonMap, mapOf(stringType, dynamicType))
+            .assignFinal(strLoadJsonMap, mapOf(stringType, dynamicType))
+            // .assignVar(strLoadJsonMap, mapOf(stringType, dynamicType))
             .statement,
         refTranslations
             .assign(
               refJsonMap.property("map<String, String>").call([
-                refer("(key, value) => MapEntry(key, value as String)"),
+                refer(
+                    "(dynamic key, dynamic value) => MapEntry<String, String>(key, value)"),
               ]),
             )
             .statement,

--- a/rosetta_generator/lib/src/helper.dart
+++ b/rosetta_generator/lib/src/helper.dart
@@ -94,12 +94,10 @@ Method generateLoader(Stone stone, Map<String, Spec> interceptorMap) {
             .call([literalString(assetLoaderTemplate)])
             .awaited
             .assignFinal(strLoadJsonStr, stringType)
-            // .assignVar(strLoadJsonStr)
             .statement,
         decodeJson
             .call([refJsonStr])
             .assignFinal(strLoadJsonMap, mapOf(stringType, dynamicType))
-            // .assignVar(strLoadJsonMap, mapOf(stringType, dynamicType))
             .statement,
         refTranslations
             .assign(

--- a/rosetta_generator/lib/src/keys.dart
+++ b/rosetta_generator/lib/src/keys.dart
@@ -13,7 +13,6 @@ Class generateKeysClass(String keysClassName, List<Translation> translations) {
                   ..name = translation.keyVariable
                   ..type = stringType
                   ..static = true
-                  // ..modifier = FieldModifier.final$
                   ..modifier = FieldModifier.constant
                   ..assignment = literalString(translation.key).code,
               ))

--- a/rosetta_generator/lib/src/keys.dart
+++ b/rosetta_generator/lib/src/keys.dart
@@ -13,7 +13,8 @@ Class generateKeysClass(String keysClassName, List<Translation> translations) {
                   ..name = translation.keyVariable
                   ..type = stringType
                   ..static = true
-                  ..modifier = FieldModifier.final$
+                  // ..modifier = FieldModifier.final$
+                  ..modifier = FieldModifier.constant
                   ..assignment = literalString(translation.key).code,
               ))
           .toList()),

--- a/rosetta_generator/lib/src/tree/implementation/visitor.dart
+++ b/rosetta_generator/lib/src/tree/implementation/visitor.dart
@@ -138,9 +138,11 @@ class TranslationVisitor extends Visitor<TranslationProduct, TranslationNode> {
       MethodBuilder methodBuilder, Interceptor interceptor) {
     methodBuilder
       ..type = MethodType.getter
-      ..body = (node.isInHelper ? refThis : refInnerHelper)
-          .property(strResolveMethodName)
+      ..body = refResolve
           .call([keysClassRef.property(node.translation.keyVariable)]).code;
+    // ..body = (node.isInHelper ? refThis : refInnerHelper)
+    //     .property(strResolveMethodName + 'test')
+    //     .call([keysClassRef.property(node.translation.keyVariable)]).code;
 
     resolutionMap.addEntries([
       MapEntry(
@@ -160,7 +162,7 @@ class TranslationVisitor extends Visitor<TranslationProduct, TranslationNode> {
         .skip(1)
         .map((e) => Parameter((pb) => pb
           ..name = e.name
-          ..type = refer(e.type.displayName)))
+          ..type = refer(e.type.getDisplayString())))
         .toList();
 
     var internalParameters = interceptor.element.parameters
@@ -188,8 +190,7 @@ class TranslationVisitor extends Visitor<TranslationProduct, TranslationNode> {
             ..body = refer(interceptor.name)
                 .call(
                   List()
-                    ..add(refer(strTranslateMethodName)
-                        .call([
+                    ..add(refer(strTranslateMethodName).call([
                       refer(keysClassName)
                           .property(node.translation.keyVariable),
                     ]))

--- a/rosetta_generator/lib/src/tree/implementation/visitor.dart
+++ b/rosetta_generator/lib/src/tree/implementation/visitor.dart
@@ -136,13 +136,18 @@ class TranslationVisitor extends Visitor<TranslationProduct, TranslationNode> {
   ///Generates a Simple Interceptor method for a given Node.
   void _buildSimpleInterceptorMethod(TranslationNode node,
       MethodBuilder methodBuilder, Interceptor interceptor) {
-    methodBuilder
-      ..type = MethodType.getter
-      ..body = refResolve
-          .call([keysClassRef.property(node.translation.keyVariable)]).code;
-    // ..body = (node.isInHelper ? refThis : refInnerHelper)
-    //     .property(strResolveMethodName + 'test')
-    //     .call([keysClassRef.property(node.translation.keyVariable)]).code;
+    if (node.isInHelper) {
+      methodBuilder
+        ..type = MethodType.getter
+        ..body = refResolve
+            .call([keysClassRef.property(node.translation.keyVariable)]).code;
+    } else {
+      methodBuilder
+        ..type = MethodType.getter
+        ..body = refInnerHelper
+            .property(strResolveMethodName)
+            .call([keysClassRef.property(node.translation.keyVariable)]).code;
+    }
 
     resolutionMap.addEntries([
       MapEntry(
@@ -169,17 +174,28 @@ class TranslationVisitor extends Visitor<TranslationProduct, TranslationNode> {
         .skip(1)
         .map((e) => refer(e.name))
         .toList();
-
-    methodBuilder
-      ..requiredParameters.addAll(methodParameters)
-      ..types.addAll(interceptor.element.typeParameters
-          .map((tp) => refer(tp.name))
-          .toList())
-      ..body = (node.isInHelper ? refThis : refInnerHelper)
-          .property(strResolveMethodName)
-          .call([keysClassRef.property(node.translation.keyVariable)])
-          .call(internalParameters)
-          .code;
+    if (node.isInHelper) {
+      methodBuilder
+        ..requiredParameters.addAll(methodParameters)
+        ..types.addAll(interceptor.element.typeParameters
+            .map((tp) => refer(tp.name))
+            .toList())
+        ..body = refResolve
+            .call([keysClassRef.property(node.translation.keyVariable)])
+            .call(internalParameters)
+            .code;
+    } else {
+      methodBuilder
+        ..requiredParameters.addAll(methodParameters)
+        ..types.addAll(interceptor.element.typeParameters
+            .map((tp) => refer(tp.name))
+            .toList())
+        ..body = refInnerHelper
+            .property(strResolveMethodName)
+            .call([keysClassRef.property(node.translation.keyVariable)])
+            .call(internalParameters)
+            .code;
+    }
 
     resolutionMap.addEntries([
       MapEntry(


### PR DESCRIPTION
fixes https://github.com/TeamWanari/rosetta/issues/43

fix: implicit-dynamic warnings in the generated code
fix: use final instead of vars
add: more typings where finals replace vars
fix: avoid using this where the resolve method is called
change: use static const instead of static final props for the Keys Enum class
add: typed MapEntry